### PR TITLE
auto install certbot dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -55,7 +55,8 @@ galaxy_info:
     - web
     - php
 
-dependencies: []
+dependencies:
+  - geerlingguy.certbot
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
   # if you add dependencies to this list.
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
 # tasks file for ansible-role-matomo
 
-- name: Download required roles
-  local_action: command ansible-galaxy install --ignore-errors -r {{ role_path }}/roles/requirements.yml
-
 - name: Configure the Web server
   import_tasks: configure-web-server.yml
   when: matomo_configure_web_server | bool


### PR DESCRIPTION
Automatically install geerlingguy.certbot dependency when requiring this role.
We can then disable the task that was responsible of that.